### PR TITLE
Change the order in admin for supplmental

### DIFF
--- a/solution/backend/supplemental_content/admin.py
+++ b/solution/backend/supplemental_content/admin.py
@@ -100,7 +100,7 @@ class SupplementalContentAdmin(BaseAdmin):
     admin_priority = 0
     list_display = ("date", "name", "description", "category", "updated_at", "approved")
     search_fields = ["date", "name", "description"]
-    ordering = ("-date", "name", "category", "-created_at", "-updated_at")
+    ordering = ("-updated_at", "-date", "name", "category", "-created_at")
     filter_horizontal = ("locations",)
     actions = [actions.mark_approved, actions.mark_not_approved]
     list_filter = [


### PR DESCRIPTION
Resolves #EREGCSC-1111

**Description-**Change order for supplmental coverage order in django admin

- expected change 1

**Steps to manually verify this change...**

1. steps to view and verify change
Go to django admin and see that supplemntal coverage order is sorted by updated date
